### PR TITLE
Return 404 for clients and versions that don't exist

### DIFF
--- a/APPLICATION_CONFIGURATION_SERVICE.md
+++ b/APPLICATION_CONFIGURATION_SERVICE.md
@@ -91,19 +91,19 @@ HTTP/1.1 304 Not Modified
 ```http
 HTTP/1.1 GET /config/ios/266
 
-HTTP/1.1 304 Not Modified
+HTTP/1.1 404 Not Found
 ```
 
 ```http
 HTTP/1.1 GET /config/ios/268
 
-HTTP/1.1 304 Not Modified
+HTTP/1.1 404 Not Found
 ```
 
 ```http
 HTTP/1.1 GET /config/android/267
 
-HTTP/1.1 304 Not Modified
+HTTP/1.1 404 Not Found
 ```
 
 ```http


### PR DESCRIPTION
When he was doing this test, @fespinoza remarked that it might be more appropriate to return `404 Not Found` rather than `304 Not Modified` for clients and/or versions that don't exist. I think so, too. What do you think, @ahultgren?